### PR TITLE
num2words 0.5.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,17 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - num2words
   commands:
     - pip check
     - num2words --help
+    - python -m pytest tests/ --ignore=tests/test_cli.py -x
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/savoirfairelinux/num2words

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,36 @@
 {% set name = "num2words" %}
-{% set version = "0.5.12" %}
+{% set version = "0.5.14" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7e7c0b0f080405aa3a1dd9d32b1ca90b3bf03bab17b8e54db05e1b78301a0988
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b066ec18e56b6616a3b38086b5747daafbaa8868b226a36127e0451c0cf379c6
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=2.7
+    - python
+    - setuptools
   run:
     - docopt >=0.6.2
-    - python >=2.7
+    - python
 
 test:
   imports:
     - num2words
+  commands:
+    - pip check
+    - num2words --help
+  requires:
+    - pip
 
 about:
   home: https://github.com/savoirfairelinux/num2words
@@ -32,6 +38,7 @@ about:
   license_family: LGPL
   license_file: COPYING
   summary: Modules to convert numbers to words. Easily extensible.
+  doc_url: https://github.com/savoirfairelinux/num2words
   dev_url: https://github.com/savoirfairelinux/num2words
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ about:
   license_family: LGPL
   license_file: COPYING
   summary: Modules to convert numbers to words. Easily extensible.
-  doc_url: https://github.com/savoirfairelinux/num2words
+  doc_url: https://github.com/savoirfairelinux/num2words/blob/master/README.rst
   dev_url: https://github.com/savoirfairelinux/num2words
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   host:
     - pip
     - python
+    - wheel
     - setuptools
   run:
     - docopt >=0.6.2


### PR DESCRIPTION
num2words 0.5.14

**Destination channel:** defaults

### Links

- [PKG-13144](https://anaconda.atlassian.net/browse/PKG-13144)
- [Upstream repository](https://github.com/savoirfairelinux/num2words)
- [PyPI](https://pypi.org/project/num2words/0.5.14/)

### Explanation of changes:

- Updated num2words from 0.5.12 to 0.5.14


[PKG-13144]: https://anaconda.atlassian.net/browse/PKG-13144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ